### PR TITLE
Logging extra info for statistics

### DIFF
--- a/server.php
+++ b/server.php
@@ -862,7 +862,10 @@ class openSearch extends webServiceServer {
                      ' repoRecs:' . $this->number_of_record_repo_calls .
                      ' repoCache:' . $this->number_of_record_repo_cached .
                      ' ' . str_replace(PHP_EOL, '', $this->watch->dump()) .
-                     ' ids:' . implode(',', $id_array));
+                     ' ids:' . implode(',', $id_array) .
+                     ' relationData:'.var_export(isset($param->relationData),true) .
+                     ' identifiers:'.sizeof($fpids).
+                     ' localIdentifiers:'.sizeof($lpids));
     return $ret;
   }
 


### PR DESCRIPTION
Vi skal have udtrukket og gemt flg. logoplysninger fra getObject-kald i OpenSearch 5.0. på Cisterne:
 - Tidspunkt for kaldet
 - Agency og Profile brugt i kaldet (+ evt. opslag i OpenAgency hvilke kilder der er med i den brugte profil)
 - Antal objekter der hentes (dvs. hvor mange identifier/localIdentifier elementer kaldet består af)
 - Om der spørges efter relationData (true/false)
 - Svartiden

Jeg har derfor tilføjet hvorvidt der søges efter relations data, og optælling af identifiers. Jeg bemærkede at koden også kigger på `agencyAndLocalIdentifer`, skal disse også optælles og logges?