### PR TITLE
Ose 11 thp

### DIFF
--- a/src/server.php
+++ b/src/server.php
@@ -3127,10 +3127,7 @@ class OpenSearch extends webServiceServer {
     }
     $relations = [];
     if (@ $rels_dom->loadXML($record_repo_addi_xml)) {  // ignore errors
-      if (!$rels_dom->getElementsByTagName('Description')->item(0)) {
-        VerboseJson::log(ERROR, 'Cannot load ' . $unit_id . ' object from RELS-EXT into DomXml');
-      }
-      else {
+      if ($rels_dom->getElementsByTagName('Description')->item(0)) {
         foreach ($rels_dom->getElementsByTagName('Description')->item(0)->childNodes as $tag) {
           if ($tag->nodeType == XML_ELEMENT_NODE) {
             if ($rel_prefix = array_search($tag->getAttribute('xmlns'), $this->xmlns))

--- a/src/server.php
+++ b/src/server.php
@@ -1030,7 +1030,7 @@ class OpenSearch extends webServiceServer {
         '&start=0' .
         '&rows=500' .
         '&defType=edismax' .
-        '&fl=rec.' . FIELD_COLLECTION_INDEX . ',' . FIELD_WORK_ID . ',' . FIELD_FEDORA_PID . ',rec.id,' . FIELD_UNIT_ID . ',unit.isPrimaryObject' .
+        '&fl=' . FIELD_COLLECTION_INDEX . ',' . FIELD_WORK_ID . ',' . FIELD_FEDORA_PID . ',rec.id,' . FIELD_UNIT_ID . ',unit.isPrimaryObject' .
         $add_fl . '&trackingId=' . VerboseJson::$tracking_id;
     VerboseJson::log(TRACE, 'Search for pids in Solr: ' . $this->repository['solr'] . str_replace('wt=phps', '?', $solr_q));
     $curl = new curl();
@@ -1103,8 +1103,13 @@ class OpenSearch extends webServiceServer {
           _Object::set_value($o->collection->_value, 'resultPosition', $rec_no + 1);
           _Object::set_value($o->collection->_value, 'numberOfObjects', 1);
 
-          if (@ !$record_repo_dom->loadXML($raw_res[$key])) {
-            VerboseJson::log(FATAL, 'Cannot load recid ' . reset($pids) . ' into DomXml');
+          if (!$raw_res[$key] || @ !$record_repo_dom->loadXML($raw_res[$key])) {
+            if (!$raw_res[$key]) {
+                VerboseJson::log(DEBUG, 'Record ' . $key . ' does not exist in index');
+            } else {
+                // Object is in index, but not in repository or parsing error
+                VerboseJson::log(FATAL, 'Cannot load recid ' . reset($pids) . ' into DomXml');
+            }
             if ($missing_record) {
               $record_repo_dom->loadXML(sprintf($missing_record, reset($pids)));
             } else {


### PR DESCRIPTION
Ændret så den ikke logger med FATAL eller ERROR for
- getRecord kald for en post som er slettet-markeret i corepo
- RELS-EXT strømme på units der ikke har nogen addi relationer (og ikke noget "Description" element). Se unit:1731812 http://corepo-introspect-service.cisterne.svc.cloud.dbc.dk/?tab=Tree%20Views&tree=870970-basis:50603733&pid=unit:1731812&selected=unit:1731812 

Desuden en rettelse af solr opslag, der prøver at udtrække feltet fl=rec.rec.collectionIdentifier fordi FIELD_COLLECTION_INDEX = rec.collectionIdentifier
